### PR TITLE
feat(input): create simple domain input field component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { DomainInput } from '@/components/domain-input';
+
 export default function Home() {
   return (
     <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
@@ -6,9 +10,16 @@ export default function Home() {
           <h1 className="text-4xl font-bold tracking-tight text-foreground mb-4">
             Domain Hunt
           </h1>
-          <p className="text-lg text-muted-foreground">
+          <p className="text-lg text-muted-foreground mb-8">
             Find and hunt for the perfect domain names for your next project
           </p>
+        </div>
+
+        <div className="w-full max-w-md">
+          <DomainInput
+            onValueChange={value => console.log('Domain value:', value)}
+            className="text-center"
+          />
         </div>
       </div>
     </div>

--- a/src/components/domain-input.tsx
+++ b/src/components/domain-input.tsx
@@ -27,12 +27,13 @@ export function DomainInput({
     const newValue = e.target.value;
     const valid = validateDomain(newValue);
 
+    // Always update the displayed value so users can see what they typed
+    setValue(newValue);
+    setIsValid(valid);
+
+    // Only call onValueChange for valid inputs
     if (valid) {
-      setValue(newValue);
-      setIsValid(true);
       onValueChange?.(newValue);
-    } else {
-      setIsValid(false);
     }
   };
 

--- a/src/components/domain-input.tsx
+++ b/src/components/domain-input.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+
+interface DomainInputProps {
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function DomainInput({
+  onValueChange,
+  placeholder = 'Enter domain name...',
+  className,
+}: DomainInputProps) {
+  const [value, setValue] = useState('');
+  const [isValid, setIsValid] = useState(true);
+
+  // Domain validation: only letters, numbers, and hyphens
+  const validateDomain = (input: string): boolean => {
+    if (input === '') return true; // Empty is valid
+    return /^[a-zA-Z0-9-]+$/.test(input);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const valid = validateDomain(newValue);
+
+    if (valid) {
+      setValue(newValue);
+      setIsValid(true);
+      onValueChange?.(newValue);
+    } else {
+      setIsValid(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={value}
+        onChange={handleInputChange}
+        placeholder={placeholder}
+        className={`${className} ${!isValid ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
+      />
+      {!isValid && (
+        <p className="text-sm text-red-500">
+          Only letters, numbers, and hyphens are allowed
+        </p>
+      )}
+      {value && isValid && (
+        <p className="text-sm text-muted-foreground">Domain: {value}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };


### PR DESCRIPTION
## Summary
Implements a basic domain input field component with validation as requested in issue #5.

### Changes Made
- ✅ Added shadcn/ui Input component to `components/ui/`
- ✅ Created domain-input.tsx component with controlled state
- ✅ Implemented basic validation (letters, numbers, hyphens only)
- ✅ Added real-time input value display
- ✅ Integrated component into main page for testing
- ✅ Added proper error handling and user feedback

### Features
- Domain name format validation (no spaces, special characters)
- Real-time display of entered domain
- Consistent styling with app theme
- Proper placeholder text
- Self-contained and reusable component

### Test Plan
- [x] Build passes without errors
- [x] Linting and formatting checks pass
- [x] Component renders correctly on main page
- [x] Validation works for invalid characters
- [x] Real-time display updates as user types
- [x] Error messages show for invalid input

Resolves #5

🤖 Generated with [Claude Code](https://claude.ai/code)