### PR TITLE
feat(input): Add pill creation logic on space key press

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,10 @@ export default function Home() {
 
         <div className="w-full max-w-md">
           <DomainInput
-            onValueChange={value => console.log('Domain value:', value)}
+            onDomainsChange={domains =>
+              console.log('Selected domains:', domains)
+            }
+            onValueChange={value => console.log('Current input:', value)}
             className="text-center"
           />
         </div>

--- a/src/components/domain-input.tsx
+++ b/src/components/domain-input.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface DomainInputProps {
   onDomainsChange?: (domains: string[]) => void;
@@ -57,15 +58,13 @@ export function DomainInput({
     setValue(newValue);
     setIsValid(valid);
 
-    // Only call onValueChange for valid inputs
-    if (valid) {
-      onValueChange?.(newValue);
-    }
+    // Call onValueChange callback for all value changes
+    onValueChange?.(newValue);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if ((e.key === ' ' || e.key === 'Tab') && value.trim()) {
-      e.preventDefault(); // Prevent space/tab from being added to input
+    if ((e.key === ' ' || e.key === 'Enter') && value.trim()) {
+      e.preventDefault(); // Prevent space/enter from being added to input
 
       if (addDomain(value.trim())) {
         setValue(''); // Clear input after successful pill creation
@@ -81,7 +80,10 @@ export function DomainInput({
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        className={`${className} ${!isValid ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
+        className={cn(
+          className,
+          !isValid && 'border-red-500 focus-visible:ring-red-500'
+        )}
       />
 
       {!isValid && (
@@ -96,16 +98,16 @@ export function DomainInput({
 
       {value && isValid && !isDuplicate(value) && (
         <p className="text-sm text-muted-foreground">
-          Press space or tab to add &ldquo;{value}&rdquo; as a pill
+          Press space or enter to add &ldquo;{value}&rdquo; as a pill
         </p>
       )}
 
       {/* Display created pills */}
       {domains.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {domains.map((domain, index) => (
+          {domains.map(domain => (
             <Badge
-              key={index}
+              key={domain}
               variant="secondary"
               className="flex items-center gap-1 pl-3 pr-1 py-1"
             >

--- a/src/components/domain-input.tsx
+++ b/src/components/domain-input.tsx
@@ -64,8 +64,8 @@ export function DomainInput({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === ' ' && value.trim()) {
-      e.preventDefault(); // Prevent space from being added to input
+    if ((e.key === ' ' || e.key === 'Tab') && value.trim()) {
+      e.preventDefault(); // Prevent space/tab from being added to input
 
       if (addDomain(value.trim())) {
         setValue(''); // Clear input after successful pill creation
@@ -96,7 +96,7 @@ export function DomainInput({
 
       {value && isValid && !isDuplicate(value) && (
         <p className="text-sm text-muted-foreground">
-          Press space to add &ldquo;{value}&rdquo; as a pill
+          Press space or tab to add &ldquo;{value}&rdquo; as a pill
         </p>
       )}
 

--- a/src/components/domain-input.tsx
+++ b/src/components/domain-input.tsx
@@ -2,25 +2,51 @@
 
 import { useState } from 'react';
 import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { X } from 'lucide-react';
 
 interface DomainInputProps {
+  onDomainsChange?: (domains: string[]) => void;
   onValueChange?: (value: string) => void;
   placeholder?: string;
   className?: string;
 }
 
 export function DomainInput({
+  onDomainsChange,
   onValueChange,
   placeholder = 'Enter domain name...',
   className,
 }: DomainInputProps) {
   const [value, setValue] = useState('');
   const [isValid, setIsValid] = useState(true);
+  const [domains, setDomains] = useState<string[]>([]);
 
   // Domain validation: only letters, numbers, and hyphens
   const validateDomain = (input: string): boolean => {
     if (input === '') return true; // Empty is valid
     return /^[a-zA-Z0-9-]+$/.test(input);
+  };
+
+  // Helper functions for domain management
+  const isDuplicate = (domain: string): boolean => {
+    return domains.includes(domain.toLowerCase());
+  };
+
+  const addDomain = (domain: string) => {
+    if (domain.trim() && !isDuplicate(domain) && validateDomain(domain)) {
+      const newDomains = [...domains, domain.toLowerCase()];
+      setDomains(newDomains);
+      onDomainsChange?.(newDomains);
+      return true;
+    }
+    return false;
+  };
+
+  const removeDomain = (domainToRemove: string) => {
+    const newDomains = domains.filter(domain => domain !== domainToRemove);
+    setDomains(newDomains);
+    onDomainsChange?.(newDomains);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,21 +63,63 @@ export function DomainInput({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === ' ' && value.trim()) {
+      e.preventDefault(); // Prevent space from being added to input
+
+      if (addDomain(value.trim())) {
+        setValue(''); // Clear input after successful pill creation
+        setIsValid(true);
+      }
+    }
+  };
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <Input
         value={value}
         onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className={`${className} ${!isValid ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
       />
+
       {!isValid && (
         <p className="text-sm text-red-500">
           Only letters, numbers, and hyphens are allowed
         </p>
       )}
-      {value && isValid && (
-        <p className="text-sm text-muted-foreground">Domain: {value}</p>
+
+      {value && isValid && isDuplicate(value) && (
+        <p className="text-sm text-yellow-600">Domain already added</p>
+      )}
+
+      {value && isValid && !isDuplicate(value) && (
+        <p className="text-sm text-muted-foreground">
+          Press space to add &ldquo;{value}&rdquo; as a pill
+        </p>
+      )}
+
+      {/* Display created pills */}
+      {domains.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {domains.map((domain, index) => (
+            <Badge
+              key={index}
+              variant="secondary"
+              className="flex items-center gap-1 pl-3 pr-1 py-1"
+            >
+              <span>{domain}</span>
+              <button
+                onClick={() => removeDomain(domain)}
+                className="ml-1 p-0.5 hover:bg-secondary-foreground/20 rounded-sm transition-colors"
+                aria-label={`Remove ${domain}`}
+              >
+                <X size={12} />
+              </button>
+            </Badge>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Summary
- ✅ Implemented space key detection for creating domain pills
- ✅ Added Badge component from shadcn/ui for pill display
- ✅ Added pill state management with add/remove functionality
- ✅ Prevented duplicate domain pills
- ✅ Added visual feedback for valid/duplicate domains
- ✅ Updated main page integration to handle domain arrays

## Implementation Details
- **Space Key Detection**: Press space to convert typed domain into a pill
- **Duplicate Prevention**: Shows warning when trying to add existing domain
- **Visual Pills**: Uses shadcn/ui Badge component with close button
- **State Management**: Maintains array of selected domains
- **Responsive Design**: Pills wrap properly on different screen sizes

## Test Plan
- [x] Domain input validation works correctly
- [x] Space key creates pills from valid domains
- [x] Duplicates are prevented with visual feedback
- [x] Pills can be removed via close button
- [x] Input clears after pill creation
- [x] Build and lint pass successfully

## Demo
Try typing a domain name and pressing space to create a pill\!

Resolves #6

🤖 Generated with [Claude Code](https://claude.ai/code)