### PR TITLE
feat(tld): create static TLD checkbox selector component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.2
+        version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -408,6 +411,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-checkbox@1.3.2':
+    resolution: {integrity: sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -630,6 +646,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2730,6 +2755,22 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
@@ -2938,6 +2979,12 @@ snapshots:
       '@types/react': 19.1.8
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DomainInput } from '@/components/domain-input';
+import { TldSelector } from '@/components/tld-selector';
 
 export default function Home() {
   return (
@@ -15,13 +16,17 @@ export default function Home() {
           </p>
         </div>
 
-        <div className="w-full max-w-md">
+        <div className="w-full max-w-md space-y-6">
           <DomainInput
             onDomainsChange={domains =>
               console.log('Selected domains:', domains)
             }
             onValueChange={value => console.log('Current input:', value)}
             className="text-center"
+          />
+
+          <TldSelector
+            onTldsChange={tlds => console.log('Selected TLDs:', tlds)}
           />
         </div>
       </div>

--- a/src/components/tld-selector.tsx
+++ b/src/components/tld-selector.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TldSelectorProps {
+  onTldsChange?: (tlds: string[]) => void;
+  className?: string;
+}
+
+const STATIC_TLDS = ['.com', '.net', '.org'];
+
+export function TldSelector({ onTldsChange, className }: TldSelectorProps) {
+  const [selectedTlds, setSelectedTlds] = useState<string[]>([]);
+
+  const handleTldToggle = (tld: string, checked: boolean) => {
+    const newSelectedTlds = checked
+      ? [...selectedTlds, tld]
+      : selectedTlds.filter(t => t !== tld);
+
+    setSelectedTlds(newSelectedTlds);
+    onTldsChange?.(newSelectedTlds);
+  };
+
+  const handleSelectAll = () => {
+    setSelectedTlds([...STATIC_TLDS]);
+    onTldsChange?.(STATIC_TLDS);
+  };
+
+  const handleDeselectAll = () => {
+    setSelectedTlds([]);
+    onTldsChange?.([]);
+  };
+
+  const allSelected = selectedTlds.length === STATIC_TLDS.length;
+  const noneSelected = selectedTlds.length === 0;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Select TLD Extensions</h3>
+          {selectedTlds.length > 0 && (
+            <span className="text-sm text-muted-foreground">
+              ({selectedTlds.length} selected)
+            </span>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSelectAll}
+            disabled={allSelected}
+          >
+            Select All
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDeselectAll}
+            disabled={noneSelected}
+          >
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 sm:grid-cols-3 md:grid-cols-3">
+        {STATIC_TLDS.map(tld => (
+          <div key={tld} className="flex items-center space-x-2">
+            <Checkbox
+              id={`tld-${tld}`}
+              checked={selectedTlds.includes(tld)}
+              onCheckedChange={checked => handleTldToggle(tld, !!checked)}
+            />
+            <label
+              htmlFor={`tld-${tld}`}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+            >
+              {tld}
+            </label>
+          </div>
+        ))}
+      </div>
+
+      {selectedTlds.length > 0 && (
+        <div className="text-sm text-muted-foreground">
+          Selected extensions: {selectedTlds.join(', ')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tld-selector.tsx
+++ b/src/components/tld-selector.tsx
@@ -73,12 +73,12 @@ export function TldSelector({ onTldsChange, className }: TldSelectorProps) {
         {STATIC_TLDS.map(tld => (
           <div key={tld} className="flex items-center space-x-2">
             <Checkbox
-              id={`tld-${tld}`}
+              id={`tld-${tld.replace('.', '-')}`}
               checked={selectedTlds.includes(tld)}
               onCheckedChange={checked => handleTldToggle(tld, !!checked)}
             />
             <label
-              htmlFor={`tld-${tld}`}
+              htmlFor={`tld-${tld.replace('.', '-')}`}
               className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
             >
               {tld}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { CheckIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -23,7 +23,7 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <CheckIcon className="w-3.5 h-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );


### PR DESCRIPTION
## Summary
- ✅ Add shadcn/ui Checkbox component with @radix-ui/react-checkbox dependency
- ✅ Create TldSelector component with .com, .net, .org static options
- ✅ Implement checkbox state management and onTldsChange callback
- ✅ Add select all / deselect all functionality with proper disabled states
- ✅ Display selected count in component header with visual feedback

## Features
- **Responsive Design**: 3-column grid layout that works on all screen sizes
- **Accessibility**: Proper labels, IDs, and keyboard navigation support
- **State Management**: Clean React state handling with TypeScript interfaces
- **Integration**: Seamlessly integrates with existing domain input component
- **Quality**: Passes all lint, format, and build checks

## Test Plan
- [x] TLD checkboxes display correctly in responsive grid
- [x] Individual checkbox selection/deselection works
- [x] Select all button enables all checkboxes and disables when all selected
- [x] Clear button clears all selections and disables when none selected
- [x] Selected count displays correctly in header
- [x] Component integrates properly with main page layout
- [x] Console logging shows correct TLD selection callbacks
- [x] Build, lint, and format checks all pass
- [x] Responsive design works on different screen sizes

## Screenshots
The TLD selector displays below the domain input with:
- Header showing "Select TLD Extensions" with selected count
- Select All / Clear buttons that enable/disable appropriately  
- 3-column grid of checkboxes for .com, .net, .org
- Visual feedback showing selected extensions

Resolves #7

🤖 Generated with [Claude Code](https://claude.ai/code)