### PR TITLE
feat(lookup): add whois fallback for DNS failures

### DIFF
--- a/src/app/api/domain-check/route.ts
+++ b/src/app/api/domain-check/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { lookup } from 'dns';
+import whois from 'whois';
 
 export async function POST(request: NextRequest) {
   try {
@@ -50,14 +51,43 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      // Other errors (network, timeout, etc.)
-      return NextResponse.json({
-        domain,
-        tld,
-        status: 'error',
-        error: errorMessage,
-        checkedAt: new Date().toISOString(),
-      });
+      // Other errors (network, timeout, etc.) - try whois fallback
+      try {
+        console.log(`DNS failed for ${fullDomain}, trying whois fallback`);
+        const whoisData = await performWhoisLookup(fullDomain, 10000);
+        const whoisStatus = parseWhoisAvailability(whoisData);
+
+        if (whoisStatus === 'unknown') {
+          return NextResponse.json({
+            domain,
+            tld,
+            status: 'error',
+            error: 'Could not determine availability from DNS or whois',
+            checkedAt: new Date().toISOString(),
+          });
+        }
+
+        return NextResponse.json({
+          domain,
+          tld,
+          status: whoisStatus,
+          checkedAt: new Date().toISOString(),
+          fallbackUsed: 'whois',
+        });
+      } catch (whoisError) {
+        const whoisErrorMessage =
+          whoisError instanceof Error
+            ? whoisError.message
+            : 'Unknown whois error';
+
+        return NextResponse.json({
+          domain,
+          tld,
+          status: 'error',
+          error: `DNS failed: ${errorMessage}, Whois failed: ${whoisErrorMessage}`,
+          checkedAt: new Date().toISOString(),
+        });
+      }
     }
   } catch (error) {
     console.error('API error:', error);
@@ -86,4 +116,77 @@ function performDnsLookup(hostname: string, timeout: number): Promise<string> {
       }
     });
   });
+}
+
+function performWhoisLookup(
+  domain: string,
+  timeout: number = 10000
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('Whois lookup timeout'));
+    }, timeout);
+
+    whois.lookup(domain, (error, data) => {
+      clearTimeout(timeoutId);
+
+      if (error) {
+        reject(error);
+      } else if (data) {
+        resolve(data);
+      } else {
+        reject(new Error('No whois data returned'));
+      }
+    });
+  });
+}
+
+function parseWhoisAvailability(
+  whoisData: string
+): 'available' | 'taken' | 'unknown' {
+  const lowerData = whoisData.toLowerCase();
+
+  // Common availability indicators
+  const availabilityIndicators = [
+    'no matching record',
+    'not found',
+    'no match',
+    'available',
+    'not registered',
+    'free',
+    'status: free',
+    'no data found',
+    'domain not found',
+  ];
+
+  // Common unavailability indicators
+  const unavailabilityIndicators = [
+    'creation date',
+    'created on',
+    'registration time',
+    'registered',
+    'domain status: clienttransferprohibited',
+    'registration-status: registeredandoperational',
+    'registrar:',
+    'registrant',
+    'admin contact',
+    'name server',
+  ];
+
+  // Check for availability indicators first
+  for (const indicator of availabilityIndicators) {
+    if (lowerData.includes(indicator)) {
+      return 'available';
+    }
+  }
+
+  // Check for unavailability indicators
+  for (const indicator of unavailabilityIndicators) {
+    if (lowerData.includes(indicator)) {
+      return 'taken';
+    }
+  }
+
+  // If we can't determine, return unknown
+  return 'unknown';
 }

--- a/src/app/api/domain-check/route.ts
+++ b/src/app/api/domain-check/route.ts
@@ -53,7 +53,15 @@ export async function POST(request: NextRequest) {
 
       // Other errors (network, timeout, etc.) - try whois fallback
       try {
-        console.log(`DNS failed for ${fullDomain}, trying whois fallback`);
+        // Use structured logging for production environments
+        console.info(
+          `DNS lookup failed for domain: ${fullDomain}, attempting whois fallback`,
+          {
+            domain: fullDomain,
+            fallback: 'whois',
+            timestamp: new Date().toISOString(),
+          }
+        );
         const whoisData = await performWhoisLookup(fullDomain, 10000);
         const whoisStatus = parseWhoisAvailability(whoisData);
 

--- a/src/types/whois.d.ts
+++ b/src/types/whois.d.ts
@@ -1,0 +1,7 @@
+declare module 'whois' {
+  interface WhoisCallback {
+    (error: Error | null, data: string | null): void;
+  }
+
+  export function lookup(domain: string, callback: WhoisCallback): void;
+}


### PR DESCRIPTION
## Summary
- Implements whois lookup as fallback when DNS lookup fails with non-NXDOMAIN errors
- Adds comprehensive whois response parsing to determine domain availability
- Maintains DNS-first strategy for optimal performance
- Includes fallback indicator in API responses when whois is used

## Changes Made
- **API Route Enhancement**: Modified `/src/app/api/domain-check/route.ts` with whois fallback logic
- **Type Definitions**: Added TypeScript declarations for whois module in `/src/types/whois.d.ts` 
- **Whois Integration**: Added `performWhoisLookup()` and `parseWhoisAvailability()` functions
- **Enhanced Error Handling**: Improved error categorization for DNS vs whois failures

## Implementation Details
- **DNS-First Approach**: DNS lookup attempted first (5s timeout)
- **Smart Fallback**: Whois used only when DNS fails with network/timeout errors (not NXDOMAIN)
- **Whois Parsing**: Comprehensive parsing logic for availability indicators
- **Timeout Handling**: 10s timeout for whois lookups with proper error handling
- **Response Format**: Maintains existing API interface with optional `fallbackUsed` field

## Test Plan
- [x] Build passes without TypeScript errors
- [x] DNS lookup for taken domains works (google.com → taken)
- [x] DNS lookup for available domains works (NXDOMAIN → available)  
- [x] Whois fallback triggers on DNS network failures
- [x] Error handling works for both DNS and whois failures
- [x] Concurrent domain checking maintains performance

## Acceptance Criteria ✅
- [x] Integrate whois package into domain checker
- [x] Use whois as fallback when DNS lookup fails
- [x] Parse whois response to determine availability
- [x] Update domain status based on whois results
- [x] Handle whois errors and timeouts
- [x] Maintain DNS-first, whois-fallback strategy

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)