### PR TITLE
Fix Husky deprecation warning in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm exec lint-staged


### PR DESCRIPTION
## Summary
Fixes the Husky deprecation warning by removing deprecated lines from `.husky/pre-commit` file.

## Changes
- Removed deprecated `#\!/usr/bin/env sh` shebang line
- Removed deprecated `. "$(dirname -- "$0")/_/husky.sh"` script loading line
- Kept the actual `pnpm exec lint-staged` command intact

## Testing
- ✅ Pre-commit hook tested and works correctly without deprecation warnings
- ✅ Lint-staged configuration still functions properly
- ✅ All quality checks passed (lint, format, build)

## Issue
Fixes #27

The deprecated lines will fail in Husky v10.0.0, so this fix prepares the codebase for future Husky upgrades.