### PR TITLE
feat(filters): persist filter toggle states across page refreshes

### DIFF
--- a/src/hooks/use-result-filters.ts
+++ b/src/hooks/use-result-filters.ts
@@ -23,9 +23,17 @@ export interface FilterCounts {
 export type ToggleStates = FilterToggleStates;
 
 export function useResultFilters(unifiedResult: UnifiedDomainResult | null) {
-  const [toggleStates, setToggleStates] = useState<ToggleStates>(() =>
-    loadFilterStates()
-  );
+  const [toggleStates, setToggleStates] = useState<ToggleStates>({
+    available: true,
+    taken: true,
+    error: true,
+  });
+
+  // Load initial state from localStorage after mount
+  useEffect(() => {
+    const storedStates = loadFilterStates();
+    setToggleStates(storedStates);
+  }, []);
 
   // Save toggle states to localStorage whenever they change
   useEffect(() => {

--- a/src/hooks/use-result-filters.ts
+++ b/src/hooks/use-result-filters.ts
@@ -1,8 +1,13 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { DomainResult, UnifiedDomainResult } from '@/types/domain';
 import { isBookmarked } from '@/services/bookmark-service';
+import {
+  loadFilterStates,
+  saveFilterStates,
+  FilterToggleStates,
+} from '@/services/filter-state-service';
 
 export type StatusToggle = 'available' | 'taken' | 'error';
 
@@ -14,18 +19,18 @@ export interface FilterCounts {
   showing: number;
 }
 
-export interface ToggleStates {
-  available: boolean;
-  taken: boolean;
-  error: boolean;
-}
+// Re-export the type from service for consistency
+export type ToggleStates = FilterToggleStates;
 
 export function useResultFilters(unifiedResult: UnifiedDomainResult | null) {
-  const [toggleStates, setToggleStates] = useState<ToggleStates>({
-    available: true,
-    taken: true,
-    error: true,
-  });
+  const [toggleStates, setToggleStates] = useState<ToggleStates>(() =>
+    loadFilterStates()
+  );
+
+  // Save toggle states to localStorage whenever they change
+  useEffect(() => {
+    saveFilterStates(toggleStates);
+  }, [toggleStates]);
 
   const { filteredResults, counts, isEmpty } = useMemo(() => {
     if (!unifiedResult) {

--- a/src/services/filter-state-service.ts
+++ b/src/services/filter-state-service.ts
@@ -1,0 +1,84 @@
+'use client';
+
+export interface FilterToggleStates {
+  available: boolean;
+  taken: boolean;
+  error: boolean;
+}
+
+const STORAGE_KEY = 'domain-hunt-filter-toggles';
+
+// Default filter states - all enabled
+const DEFAULT_STATES: FilterToggleStates = {
+  available: true,
+  taken: true,
+  error: true,
+};
+
+/**
+ * Load filter toggle states from localStorage
+ * Returns default states if localStorage is unavailable or data is corrupted
+ */
+export const loadFilterStates = (): FilterToggleStates => {
+  // Check if running on server
+  if (typeof window === 'undefined') {
+    return DEFAULT_STATES;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_STATES;
+    }
+
+    const parsed = JSON.parse(stored) as FilterToggleStates;
+
+    // Validate that all required properties exist and are booleans
+    if (
+      typeof parsed.available === 'boolean' &&
+      typeof parsed.taken === 'boolean' &&
+      typeof parsed.error === 'boolean'
+    ) {
+      return parsed;
+    }
+
+    // If validation fails, return defaults
+    console.warn('Invalid filter states in localStorage, using defaults');
+    return DEFAULT_STATES;
+  } catch (error) {
+    console.error('Failed to load filter states from localStorage:', error);
+    return DEFAULT_STATES;
+  }
+};
+
+/**
+ * Save filter toggle states to localStorage
+ */
+export const saveFilterStates = (states: FilterToggleStates): void => {
+  // Check if running on server
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(states));
+  } catch (error) {
+    console.error('Failed to save filter states to localStorage:', error);
+  }
+};
+
+/**
+ * Clear filter toggle states from localStorage
+ */
+export const clearFilterStates = (): void => {
+  // Check if running on server
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear filter states from localStorage:', error);
+  }
+};


### PR DESCRIPTION
## Summary
Implements localStorage persistence for filter toggle states to maintain user preferences across page refreshes.

**Changes:**
- ✅ Add `filter-state-service.ts` with localStorage persistence logic
- ✅ Update `use-result-filters.ts` hook to load/save toggle states automatically  
- ✅ Follow existing codebase localStorage patterns with SSR safety
- ✅ Handle corrupted/invalid data gracefully with fallback to defaults
- ✅ Use storage key `domain-hunt-filter-toggles` for consistency

**Implementation Details:**
- Initialize `toggleStates` from localStorage on component mount
- Auto-save `toggleStates` to localStorage when state changes via `useEffect`
- Comprehensive error handling with console warnings for debugging
- Data validation to ensure stored values are valid booleans
- Server-side rendering compatibility checks

**Testing:**
- ✅ Manual testing confirmed persistence works across page refreshes
- ✅ All existing filter functionality remains intact
- ✅ Quality checks passed: format, lint, build

**Backward Compatibility:**
- Maintains all existing filter functionality
- No breaking changes to component interfaces
- Graceful fallback when localStorage is unavailable

Resolves #38

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>