### PR TITLE
refactor: extract bookmark sync logic into dedicated hook (#49)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState } from 'react';
 import { DomainInput } from '@/components/domain-input';
 import { TldSelector } from '@/components/tld-selector';
 import { BookmarkButton } from '@/components/bookmark-button';
@@ -11,10 +11,11 @@ import {
   retryDomainCheck,
 } from '@/services/domain-checker';
 import { getStatusColor } from '@/lib/utils';
-import { UnifiedLookupProgress, UnifiedDomainResult } from '@/types/domain';
+import { UnifiedLookupProgress } from '@/types/domain';
 import { Loader2, Filter, RefreshCw } from 'lucide-react';
-import { useHomepageState } from '@/hooks/useHomepageState';
+import { useHomepageState } from '@/hooks/use-homepage-state';
 import { useResultFilters } from '@/hooks/use-result-filters';
+import { useBookmarkSync } from '@/hooks/use-bookmark-sync';
 import { FilterToggleButton } from '@/components/filter-toggle-button';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { toast } from 'sonner';
@@ -22,7 +23,6 @@ import { formatErrorForToast, isOffline } from '@/utils/error-handling';
 import {
   updateBookmarkStatus,
   isBookmarked,
-  getAllBookmarks,
 } from '@/services/bookmark-service';
 
 export default function Home() {
@@ -46,106 +46,8 @@ export default function Home() {
   const { filteredResults, toggleStates, counts, isEmpty, onToggle } =
     useResultFilters(unifiedResult);
 
-  // Track if we've already synced this unifiedResult to avoid infinite loops
-  const syncedResultRef = useRef<string | null>(null);
-
-  // Helper function to sync bookmarks with unified result
-  const syncBookmarksWithUnifiedResult = useCallback(
-    (
-      unifiedResult: UnifiedDomainResult,
-      setUnifiedResult: (result: UnifiedDomainResult) => void,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      syncedResultRef?: React.MutableRefObject<string | null>
-    ) => {
-      if (!unifiedResult) return;
-
-      // Get current bookmarks to sync status
-      const bookmarks = getAllBookmarks();
-      const bookmarkMap = new Map();
-      bookmarks.forEach(bookmark => {
-        const key = `${bookmark.domain}${bookmark.tld}`;
-        bookmarkMap.set(key, bookmark.lastKnownStatus);
-      });
-
-      // Update unifiedResult with latest bookmark statuses
-      let hasChanges = false;
-      const updatedResultsByDomain = new Map();
-
-      Array.from(unifiedResult.resultsByDomain.entries()).forEach(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (entry: any) => {
-          const [domain, domainResult] = entry;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const updatedResults = domainResult.results.map((result: any) => {
-            const key = `${result.domain}${result.tld}`;
-            const bookmarkStatus = bookmarkMap.get(key);
-
-            // If this domain is bookmarked and status is different, update it
-            if (bookmarkStatus && bookmarkStatus !== result.status) {
-              hasChanges = true;
-              return { ...result, status: bookmarkStatus };
-            }
-            return result;
-          });
-
-          updatedResultsByDomain.set(domain, {
-            ...domainResult,
-            results: updatedResults,
-          });
-        }
-      );
-
-      // Update state if there were changes
-      if (hasChanges) {
-        setUnifiedResult({
-          ...unifiedResult,
-          resultsByDomain: updatedResultsByDomain,
-        });
-      }
-    },
-    []
-  );
-
-  // Sync homepage results with bookmark changes when unifiedResult loads
-  useEffect(() => {
-    if (!unifiedResult) return;
-
-    // Create a simple hash of the result to track if we've already synced it
-    const resultHash = `${unifiedResult.overallProgress?.total}-${unifiedResult.overallProgress?.completed}`;
-    if (syncedResultRef.current === resultHash) return;
-
-    syncBookmarksWithUnifiedResult(
-      unifiedResult,
-      setUnifiedResult,
-      syncedResultRef
-    );
-
-    // Mark this result as synced
-    syncedResultRef.current = resultHash;
-  }, [unifiedResult, setUnifiedResult, syncBookmarksWithUnifiedResult]);
-
-  // Listen for bookmark changes and sync with homepage results
-  useEffect(() => {
-    const handleBookmarkChange = () => {
-      if (!unifiedResult) return;
-      syncBookmarksWithUnifiedResult(unifiedResult, setUnifiedResult);
-    };
-
-    // Listen for both custom events and storage events for cross-tab sync
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === 'bookmarkChangeSignal') {
-        handleBookmarkChange();
-      }
-    };
-
-    window.addEventListener('bookmarkStatsChanged', handleBookmarkChange);
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => {
-      window.removeEventListener('bookmarkStatsChanged', handleBookmarkChange);
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, [unifiedResult, setUnifiedResult, syncBookmarksWithUnifiedResult]);
+  // Use bookmark sync hook for cross-tab synchronization
+  useBookmarkSync({ unifiedResult, setUnifiedResult });
 
   const handleCheckDomains = async () => {
     if (domains.length === 0 || selectedTlds.length === 0) {

--- a/src/hooks/use-bookmark-sync.ts
+++ b/src/hooks/use-bookmark-sync.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { UnifiedDomainResult } from '@/types/domain';
+import { getAllBookmarks } from '@/services/bookmark-service';
+
+interface UseBookmarkSyncProps {
+  unifiedResult: UnifiedDomainResult | null;
+  setUnifiedResult: (result: UnifiedDomainResult) => void;
+}
+
+export function useBookmarkSync({
+  unifiedResult,
+  setUnifiedResult,
+}: UseBookmarkSyncProps) {
+  // Track if we've already synced this unifiedResult to avoid infinite loops
+  const syncedResultRef = useRef<string | null>(null);
+
+  // Helper function to sync bookmarks with unified result
+  const syncBookmarksWithUnifiedResult = useCallback(
+    (
+      unifiedResult: UnifiedDomainResult,
+      setUnifiedResult: (result: UnifiedDomainResult) => void,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      syncedResultRef?: React.MutableRefObject<string | null>
+    ) => {
+      if (!unifiedResult) return;
+
+      // Get current bookmarks to sync status
+      const bookmarks = getAllBookmarks();
+      const bookmarkMap = new Map();
+      bookmarks.forEach(bookmark => {
+        const key = `${bookmark.domain}${bookmark.tld}`;
+        bookmarkMap.set(key, bookmark.lastKnownStatus);
+      });
+
+      // Update unifiedResult with latest bookmark statuses
+      let hasChanges = false;
+      const updatedResultsByDomain = new Map();
+
+      Array.from(unifiedResult.resultsByDomain.entries()).forEach(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (entry: any) => {
+          const [domain, domainResult] = entry;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const updatedResults = domainResult.results.map((result: any) => {
+            const key = `${result.domain}${result.tld}`;
+            const bookmarkStatus = bookmarkMap.get(key);
+
+            // If this domain is bookmarked and status is different, update it
+            if (bookmarkStatus && bookmarkStatus !== result.status) {
+              hasChanges = true;
+              return { ...result, status: bookmarkStatus };
+            }
+            return result;
+          });
+
+          updatedResultsByDomain.set(domain, {
+            ...domainResult,
+            results: updatedResults,
+          });
+        }
+      );
+
+      // Update state if there were changes
+      if (hasChanges) {
+        setUnifiedResult({
+          ...unifiedResult,
+          resultsByDomain: updatedResultsByDomain,
+        });
+      }
+    },
+    []
+  );
+
+  // Sync homepage results with bookmark changes when unifiedResult loads
+  useEffect(() => {
+    if (!unifiedResult) return;
+
+    // Create a simple hash of the result to track if we've already synced it
+    const resultHash = `${unifiedResult.overallProgress?.total}-${unifiedResult.overallProgress?.completed}`;
+    if (syncedResultRef.current === resultHash) return;
+
+    syncBookmarksWithUnifiedResult(
+      unifiedResult,
+      setUnifiedResult,
+      syncedResultRef
+    );
+
+    // Mark this result as synced
+    syncedResultRef.current = resultHash;
+  }, [unifiedResult, setUnifiedResult, syncBookmarksWithUnifiedResult]);
+
+  // Listen for bookmark changes and sync with homepage results
+  useEffect(() => {
+    const handleBookmarkChange = () => {
+      if (!unifiedResult) return;
+      syncBookmarksWithUnifiedResult(unifiedResult, setUnifiedResult);
+    };
+
+    // Listen for both custom events and storage events for cross-tab sync
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'bookmarkChangeSignal') {
+        handleBookmarkChange();
+      }
+    };
+
+    window.addEventListener('bookmarkStatsChanged', handleBookmarkChange);
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('bookmarkStatsChanged', handleBookmarkChange);
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [unifiedResult, setUnifiedResult, syncBookmarksWithUnifiedResult]);
+
+  return {
+    syncBookmarksWithUnifiedResult,
+  };
+}

--- a/src/hooks/use-homepage-state.ts
+++ b/src/hooks/use-homepage-state.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import { UnifiedDomainResult } from '@/types/domain';
+import {
+  loadHomepageState,
+  saveHomepageState,
+  clearHomepageState,
+} from '@/services/homepage-state-service';
+
+export function useHomepageState() {
+  const [domains, setDomains] = useState<string[]>([]);
+  const [selectedTlds, setSelectedTlds] = useState<string[]>([]);
+  const [unifiedResult, setUnifiedResult] =
+    useState<UnifiedDomainResult | null>(null);
+
+  // Load saved state on mount
+  useEffect(() => {
+    const savedState = loadHomepageState();
+    if (savedState) {
+      if (savedState.domains && savedState.domains.length > 0) {
+        setDomains(savedState.domains);
+      }
+      if (savedState.selectedTlds && savedState.selectedTlds.length > 0) {
+        setSelectedTlds(savedState.selectedTlds);
+      }
+      if (savedState.unifiedResult) {
+        setUnifiedResult(savedState.unifiedResult);
+      }
+    }
+  }, []);
+
+  // Save state whenever relevant data changes
+  useEffect(() => {
+    // Only save if we have meaningful data
+    if (domains.length > 0 || selectedTlds.length > 0 || unifiedResult) {
+      saveHomepageState({
+        domains,
+        selectedTlds,
+        unifiedResult,
+      });
+    }
+  }, [domains, selectedTlds, unifiedResult]);
+
+  const clearState = () => {
+    setDomains([]);
+    setSelectedTlds([]);
+    setUnifiedResult(null);
+    clearHomepageState();
+  };
+
+  return {
+    domains,
+    selectedTlds,
+    unifiedResult,
+    setDomains,
+    setSelectedTlds,
+    setUnifiedResult,
+    clearState,
+  };
+}


### PR DESCRIPTION
## Summary
Extract complex bookmark synchronization logic from the large `page.tsx` file into a dedicated `use-bookmark-sync.ts` hook for better separation of concerns and reusability.

This is the **final piece** of the homepage refactor epic #50, focusing on the most complex logic involving cross-tab communication and state management.

## Changes
- ✅ Created `src/hooks/use-bookmark-sync.ts` with complete bookmark sync functionality
- ✅ Extracted cross-tab synchronization using storage events  
- ✅ Moved bookmark status syncing with domain results
- ✅ Encapsulated event listeners for bookmark changes
- ✅ Proper state management for bookmark sync tracking
- ✅ Updated `src/app/page.tsx` to use the new hook
- ✅ Cleaned up unused imports (useEffect, useCallback, useRef, getAllBookmarks, UnifiedDomainResult)
- ✅ All functionality preserved including cross-tab communication
- ✅ Build passes successfully

## Context
This is **Phase 3** (final phase) of the homepage refactor epic #50. This handles the most complex logic with cross-tab communication and critical bookmark synchronization functionality.

**Reduced page.tsx by ~100 lines** while maintaining all existing functionality.

## Hook Details
- **use-bookmark-sync**: 116 lines, handles complete bookmark sync logic
- Manages cross-tab communication via storage events
- Automatic syncing of bookmark status changes with domain results  
- Proper cleanup of event listeners
- Reusable and well-encapsulated

## Implements
- #49 Extract bookmark sync logic into dedicated hook

## Epic Completion
**✅ COMPLETES homepage refactor epic #50**

All 8 subtasks have been successfully implemented across 4 PRs:
- PR #51: Hook renaming (#42) ✅
- PR #52: Basic components (#43, #44, #46) ✅  
- PR #53: Interactive components (#45, #47, #48) ✅
- PR #54: Logic extraction (#49) ✅

The original 585-line page.tsx has been successfully refactored into well-separated, maintainable components and hooks while preserving all functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)