### PR TITLE
fix(ui): remove extra dots in domain display

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,7 +131,7 @@ export default function Home() {
   };
 
   const handleRetryDomain = async (domain: string, tld: string) => {
-    const domainKey = `${domain}.${tld}`;
+    const domainKey = `${domain}${tld}`;
 
     // Check if already retrying
     if (retryingDomains.has(domainKey)) {
@@ -188,11 +188,11 @@ export default function Home() {
       // Show success/error toast
       if (result.status === 'error') {
         const errorFormat = formatErrorForToast(result.error || 'Retry failed');
-        toast.error(`Retry failed for ${domain}.${tld}`, {
+        toast.error(`Retry failed for ${domain}${tld}`, {
           description: errorFormat.description,
         });
       } else {
-        toast.success(`Successfully retried ${domain}.${tld}`, {
+        toast.success(`Successfully retried ${domain}${tld}`, {
           description: `Domain is ${result.status}`,
         });
       }
@@ -201,7 +201,7 @@ export default function Home() {
       const errorFormat = formatErrorForToast(
         error instanceof Error ? error : 'Unknown error occurred'
       );
-      toast.error(`Failed to retry ${domain}.${tld}`, {
+      toast.error(`Failed to retry ${domain}${tld}`, {
         description: errorFormat.description,
       });
     } finally {

--- a/src/components/domain-result-card.tsx
+++ b/src/components/domain-result-card.tsx
@@ -19,7 +19,8 @@ export function DomainResultCard({
   return (
     <div className="flex items-center justify-between text-xs p-2 bg-container-bg border border-container-border rounded">
       <span className="font-mono">
-        {result.domain}.{result.tld}
+        {result.domain}
+        {result.tld}
       </span>
       <div className="flex items-center space-x-2">
         <Badge

--- a/src/components/domain-results.tsx
+++ b/src/components/domain-results.tsx
@@ -52,10 +52,10 @@ export function DomainResults({
             <div className="grid gap-1">
               {domainResult.results.map(result => (
                 <DomainResultCard
-                  key={`${result.domain}.${result.tld}`}
+                  key={`${result.domain}${result.tld}`}
                   result={result}
                   isRetrying={retryingDomains.has(
-                    `${result.domain}.${result.tld}`
+                    `${result.domain}${result.tld}`
                   )}
                   onRetry={onRetryDomain}
                 />

--- a/src/hooks/use-bookmark-sync.ts
+++ b/src/hooks/use-bookmark-sync.ts
@@ -30,7 +30,7 @@ export function useBookmarkSync(
       const bookmarks = getAllBookmarks();
       const bookmarkMap = new Map();
       bookmarks.forEach(bookmark => {
-        const key = `${bookmark.domain}.${bookmark.tld}`;
+        const key = `${bookmark.domain}${bookmark.tld}`;
         bookmarkMap.set(key, bookmark.lastKnownStatus);
       });
 
@@ -44,7 +44,7 @@ export function useBookmarkSync(
           const [domain, domainResult] = entry;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const updatedResults = domainResult.results.map((result: any) => {
-            const key = `${result.domain}.${result.tld}`;
+            const key = `${result.domain}${result.tld}`;
             const bookmarkStatus = bookmarkMap.get(key);
 
             // If this domain is bookmarked and status is different, update it


### PR DESCRIPTION
## Summary
Fixed domain names displaying with extra dots (e.g., "husni.com." instead of "husni.com").

## Problem
TLD values already include the dot prefix (`.com`, `.net`, `.org`) but UI components were incorrectly concatenating them with additional dots, resulting in malformed domain displays.

## Changes
- Fixed domain display in `DomainResultCard` component
- Fixed retry domain key generation in homepage
- Fixed toast messages to show correct domain names  
- Fixed bookmark sync domain key matching

## Root Cause
- TLD extensions are stored with dots: `.com`, `.net`, `.org`
- API correctly concatenates: `${domain}${tld}` → `husni.com` ✅
- UI components incorrectly used: `${result.domain}.${result.tld}` → `husni.com.` ❌

## Test plan
- [x] Verify domain names display correctly without extra dots
- [x] Check toast notifications show proper domain names
- [x] Ensure bookmark synchronization works with correct keys
- [x] Confirm no TypeScript or linting errors

🤖 Generated with [Claude Code](https://claude.ai/code)